### PR TITLE
Use the official Person example from the deployment; add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# playground
-Combines the JSON-SCHEMA editor and JSON-LD playground
+# OO-LD Playground
+
+An interactive playground for [OO-LD](https://oo-ld.org/) schemas. It combines a JSON Schema form editor ([json-editor](https://github.com/json-editor/json-editor)) with the [JSON-LD playground](https://github.com/json-ld/json-ld.org), so a single OO-LD document can be exercised as both at once: the JSON Schema part drives validation and the generated form, the `@context` part drives the RDF output.
+
+Live: <https://oo-ld.github.io/playground/>
+
+## What the panes show
+
+- **Schema** - the OO-LD document being edited (JSON). Press "Set Schema" to apply your edits.
+- **Form** - the user interface generated from the schema by json-editor.
+- **Data** - the JSON instance produced by the form. Press "Set Value" to push edited JSON back into the form.
+- **Validation** - JSON Schema validation errors for the current instance.
+- **JSON-LD** - the instance interpreted as linked data, showing the expanded form and the resulting RDF.
+
+## The default example
+
+The playground opens with the official OO-LD `Person` example, fetched at page load from the canonical deployment:
+
+<https://oo-ld.org/latest/schemas/Person.schema.json>
+
+`Person` builds on `Thing` through both `allOf` (so JSON Schema validators apply the base rules) and `@context` (so JSON-LD resolves the inherited term mappings). That pairing is the core OO-LD inheritance idiom.
+
+Loading the example over the network rather than vendoring a copy keeps the playground in step with the specification. Because the published schemas use relative references such as `"Thing.schema.json"`, the playground rewrites them to absolute URLs against `https://oo-ld.org/latest/schemas/` before handing the document to the editor. If the deployment cannot be reached, the playground falls back to a small offline copy of the `Minimal` example and logs a warning to the browser console.
+
+The full official example set is browsable at <https://github.com/OO-LD/oold-schema/tree/main/examples> and served under <https://oo-ld.org/latest/schemas/>. To try any of them, paste the schema into the Schema pane and press "Set Schema".
+
+## Sharing what you built
+
+The "Direct Link" button encodes the current schema, data and editor options into the URL as a `?data=` parameter (JSON, LZString-compressed to base64). Anyone opening that link gets your exact state. A `?data=` link always takes precedence over the default example, so shared links keep working unchanged.
+
+"Reset Playground" clears the parameters and returns to the default example.
+
+## Related playgrounds
+
+| Playground | Purpose |
+|---|---|
+| [playground](https://oo-ld.github.io/playground/) | JSON editing mode (this one) |
+| [playground-yaml](https://oo-ld.github.io/playground-yaml/) | YAML editing mode |
+| [playground-python-yaml](https://oo-ld.github.io/playground-python-yaml/) | YAML mode plus in-browser Python code generation |
+| [playground-awl](https://oo-ld.github.io/playground-awl/) | Abstract Workflow Language |
+
+## Local development
+
+This is a static page with no build step. The JSON-LD playground is included as a git submodule:
+
+```bash
+git clone --recurse-submodules https://github.com/OO-LD/playground.git
+cd playground
+python -m http.server
+```
+
+Then open <http://localhost:8000/>. Serving over HTTP rather than opening `index.html` directly matters, because the default example is fetched with `fetch()`.
+
+## The legacy `examples/` directory
+
+`examples/Person.schema.json` and `examples/Thing.schema.json` are an older copy that predates the current OO-LD conventions. They are kept only so that previously shared `?data=` links, which reference them by URL, keep resolving. Do not build on them: use the canonical schemas at <https://oo-ld.org/latest/schemas/> instead.
+
+## More about OO-LD
+
+- Documentation: <https://oo-ld.org/>
+- Specification: <https://oo-ld.org/latest/spec/>
+- Main repository: <https://github.com/OO-LD/oold-schema>

--- a/index.html
+++ b/index.html
@@ -161,74 +161,79 @@
     </div>
     <script>
 
-        var defaultSchema = {
-          "@context": [
-            "https://oo-ld.github.io/playground/examples/Thing.schema.json",
-            {
-              "date": "schema:birthDate",
-              "gender": "schema:gender",
-              "location": "schema:address",
-              "city": "schema:addressLocality",
-              "state": "schema:addressRegion"
-            }
-          ],
-          "allOf": [
-            {
-              "$ref": "https://oo-ld.github.io/playground/examples/Thing.schema.json"
-            }
-          ],
-          "$comment": "A Person is a Thing, so we import the context (per @context) and schema (per allOf.$ref) of Thing",
-          "title": "Person",
+        // The official OO-LD examples are published by the oold-schema deployment.
+        // Loading the default example from there keeps this playground in sync with
+        // the canonical source instead of vendoring a copy that drifts.
+        var OOLD_SCHEMA_BASE = 'https://oo-ld.org/latest/schemas/'
+        var OOLD_DEFAULT_SCHEMA_URL = OOLD_SCHEMA_BASE + 'Person.schema.json'
+
+        // Only used when the deployment is unreachable, so the editor still renders
+        // something valid offline. Mirrors examples/Minimal.schema.json.
+        var fallbackSchema = {
+          "$schema": "https://oo-ld.org/latest/meta/oold-meta-schema.json",
+          "$id": OOLD_SCHEMA_BASE + "Minimal.schema.json",
+          "@context": {
+            "schema": "http://schema.org/",
+            "name": "schema:name"
+          },
+          "title": "Minimal",
           "type": "object",
-          "required": [
-            "name"
-          ],
           "properties": {
-            "type": {
-              "$comment": "Already defined in playground:Thing -> we override just the default",
-              "default": "playground:Person"
-            },
-            "name": {
-              "description": "First and Last name",
-              "minLength": 4,
-              "default": "Jeremy Dorn"
-            },
-            "age": {
-              "type": "integer",
-              "default": 25,
-              "minimum": 18,
-              "maximum": 99
-            },
-            "gender": {
-              "type": "string",
-              "enum": [
-                "male",
-                "female",
-                "other"
-              ]
-            },
-            "date": {
-              "type": "string",
-              "format": "date",
-              "options": {
-                "flatpickr": {}
-              }
-            },
-            "location": {
-              "type": "object",
-              "title": "Location",
-              "properties": {
-                "city": {
-                  "type": "string",
-                  "default": "San Francisco"
-                },
-                "state": {
-                  "type": "string",
-                  "default": "CA"
-                }
-              }
-            }
+            "name": { "type": "string", "description": "Name of the thing" }
           }
+        }
+
+        var isRelativeRef = function (value) {
+            return typeof value === 'string' && !/^[a-z][a-z0-9+.-]*:/i.test(value) && value.charAt(0) !== '#' && value.slice(0, 2) !== '//'
+        }
+
+        // A remote context is either a string or an array whose string entries are
+        // context URLs; the object entries are term definitions and must stay as they
+        // are (their values are CURIEs like schema:name, not references).
+        var absolutizeContext = function (context, base) {
+            if (isRelativeRef(context)) return new URL(context, base).href
+            if (Array.isArray(context)) {
+                return context.map(function (entry) {
+                    return isRelativeRef(entry) ? new URL(entry, base).href : entry
+                })
+            }
+            return context
+        }
+
+        // The published schemas use relative ids and references (e.g. "Thing.schema.json")
+        // which would otherwise resolve against this page instead of the deployment.
+        var absolutizeRefs = function (node, base) {
+            if (Array.isArray(node)) {
+                node.forEach(function (item) { absolutizeRefs(item, base) })
+                return node
+            }
+            if (node === null || typeof node !== 'object') return node
+            Object.keys(node).forEach(function (key) {
+                var value = node[key]
+                if (key === '@context') {
+                    node[key] = absolutizeContext(value, base)
+                } else if ((key === '$id' || key === '$ref' || key === 'x-oold-range') && isRelativeRef(value)) {
+                    node[key] = new URL(value, base).href
+                } else {
+                    absolutizeRefs(value, base)
+                }
+            })
+            return node
+        }
+
+        var loadDefaultSchema = function () {
+            return fetch(OOLD_DEFAULT_SCHEMA_URL)
+                .then(function (response) {
+                    if (!response.ok) throw new Error('HTTP ' + response.status)
+                    return response.json()
+                })
+                .then(function (schema) {
+                    return absolutizeRefs(schema, OOLD_SCHEMA_BASE)
+                })
+                .catch(function (reason) {
+                    console.warn('Could not load ' + OOLD_DEFAULT_SCHEMA_URL + ', falling back to the offline example: ' + reason)
+                    return fallbackSchema
+                })
         }
         // parse url -> merge options -> refreshUI() -> initJsoneditor() -> direct link
 
@@ -239,7 +244,7 @@
         var defaultOptions = {
             iconlib: 'fontawesome5',
             object_layout: 'normal',
-            schema: defaultSchema,
+            schema: fallbackSchema,
             show_errors: 'interaction',
             theme: 'bootstrap4',
             ajax: true,
@@ -673,7 +678,13 @@
             refreshUI()
         })
 
-        parseUrl()
+        // Resolve the canonical default before the editor initializes. A ?data=
+        // permalink carries its own schema and still wins, because mergeOptions()
+        // assigns data.options over defaultOptions.
+        loadDefaultSchema().then(function (schema) {
+            defaultOptions.schema = schema
+            parseUrl()
+        })
 
     </script>
 </body>


### PR DESCRIPTION
## Problem

The playground opened with the stock json-editor demo schema ("Jeremy Dorn"), not an official OO-LD example, and it `$ref`ed a stale vendored copy at `oo-ld.github.io/playground/examples/Thing.schema.json` whose lineage predates the current OO-LD conventions (no `$schema`/meta-schema, no `x-oold-*`, `playground:` prefix). The README was a two-line stub.

## Change

- Load the default example live from the canonical deployment: https://oo-ld.org/latest/schemas/Person.schema.json . `Person` builds on `Thing` via `allOf` + `@context`, the core OO-LD inheritance idiom.
- The published schemas use relative references (`"Thing.schema.json"`, `$id`, `x-oold-range`); a small helper rewrites them to absolute URLs against `https://oo-ld.org/latest/schemas/` so json-editor can resolve them (open CORS confirmed).
- Offline fallback: an inline `Minimal` example plus a console warning if the fetch fails, so the editor never renders empty.
- `?data=` shared permalinks still take precedence: `mergeOptions()` assigns `data.options` over `defaultOptions`, so a link's own schema overrides the fetched default.
- The legacy `examples/` copies are kept (not deleted) so older shared links that reference them by URL keep resolving; they are just no longer the default.
- New README documenting the panes, the default example and the canonical example set, `?data=` sharing, the sibling playgrounds, and local development.

## Verification

- `node --check` on the inline script: OK.
- The ref-rewriting was unit-tested against the real deployed `Person.schema.json`: `$id`, `@context` URL entry, `allOf.$ref` and `x-oold-range` are absolutized, while CURIEs (`schema:name`) and `x-oold-instance-rdf-type` are left intact.
- Ran locally over HTTP with the `json-ld` submodule populated: the Person example loads and the form, JSON output and JSON-LD/RDF panes populate. Browser runtime rendering was verified manually; there is no automated browser test.